### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
  "description": "Enzyme extensions tailored at improving dealing with shallowly rendered wrappers",
  "main": "src/index.js",
  "scripts": {
-  "postinstall": "check-node-version --package --print",
   "precommit": "lint-staged",
   "format": "npm run format:md && npm run format:js",
   "commitmsg": "commitlint -e $GIT_PARAMS",


### PR DESCRIPTION
When trying to install without having `check-node-version` in the environment, the install fails with

```
error An unexpected error occurred: "/<...>/@commercetools/enzyme-extensions: Command failed.
Exit code: 127
Command: sh
Arguments: -c check-node-version --package --print
Directory: /<...>/node_modules/@commercetools/enzyme-extensions
Output:

```

We need to remove the `postinstall` hook.

`npm i -g check-node-version` or `yarn add @commercetools/enzyme-extensions -D --ignore-scripts` serve as a workaround in the meantime.