### PR TITLE
Make renderProp more convenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ class App extends React.Component {
         />
       </div>
     );
-  },
-});
+  }
+}
 ```
 
 If we wanted to test the `render` prop the `<App /` component passes to `<Mouse />`, we'd traditionally have to do:
@@ -191,7 +191,7 @@ describe('when rendering `<App>`', () => {
   });
 
   it('should render the mouse position', () => {
-    expect(wrapper.contains(<div>Cursor is at 2</div>)).toBe(true);
+    expect(wrapper.equals(<div>Cursor is at 2</div>)).toBe(true);
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This quickly gets out of hand when traversing multiple render props, and the "li
 ```jsx
 const wrapper = shallow(<App />)
   .find(Mouse)
-  .renderProp(props => props.render({ x: 0, y: 0 }));
+  .renderProp('render', { x: 0, y: 0 });
 
 expect(wrapper.text()).toEqual('The mouse position is (0, 0)');
 ```
@@ -96,7 +96,7 @@ Here are some examples of how this method simplifies tests:
 -);
 +wrapper = shallow(<App />)
 +  .find(Mouse)
-+  .renderProp(props => props.render({ x: 2 }));
++  .renderProp('render', { x: 2 }));
 ```
 
 ```diff
@@ -114,9 +114,9 @@ Here are some examples of how this method simplifies tests:
 -);
 +wrapper = shallow(<App />)
 +  .find(Mouse)
-+  .renderProp(props => props.render({ x: 2 }))
++  .renderProp('render' ,{ x: 2 })
 +  .find(Mouse)
-+  .renderProp(props => props.render({ y: 4 }));
++  .renderProp('render' ,{ y: 4 });
 ```
 
 This is more readable and easier to follow. At the same time everything is still rendered `shallow`ly and the unit under test is well scoped.
@@ -152,11 +152,11 @@ import Adapter from 'enzyme-adapter-react-xx';
 import configure from '@commercetools/enzyme-extensions';
 import ShallowWrapper from 'enzyme/ShallowWrapper';
 
-// you likely had this part already
+// You likely had this part already
 Enzyme.configure({ adapter: new Adapter() });
 
-// this is the actual integration which behind
-// the scenes extends the prototype of the passed in `ShallowWrapper`
+// This is the actual integration.
+// Behind the scenes this extends the prototype of the passed in `ShallowWrapper`
 configure(ShallowWrapper);
 ```
 
@@ -171,7 +171,7 @@ import { shallow } from 'enzyme'
 describe('when rendering `<App>`', () => {
   const App = () => (
     <div id="app">
-      <Mouse render={({ x }) => <div>Cursor is at {x}</div>} />
+      <Mouse render={(x, y) => <div>Cursor is at {x} {y}</div>} />
     </div>
   );
 
@@ -184,7 +184,10 @@ describe('when rendering `<App>`', () => {
       // This is where we are actually using the renderProp function
       // Since we defined it on the prototype in the Installation step,
       // it does not need to be imported into the test itself.
-      .renderProp(props => props.render({ x: 2 }));
+      // The first argument is the name of the prop we want to call,
+      // all remaining arguments are passed as the arguments of the
+      // render prop call
+      .renderProp('render', 2, 4);
   });
 
   it('should render the mouse position', () => {
@@ -193,7 +196,18 @@ describe('when rendering `<App>`', () => {
 });
 ```
 
+## Other functions
+
+`renderProp` is built as an easy to use test helper for the most common cases.
+In case you need more control, you can use `drill` instead. `drill` offers more flexibility as:
+
+* the prop-to-call can be derived from the other props
+* the returned element can be set dynamically
+
+See the [`drill`](docs/drill.md) documentation for more.
+
 ## Documentation
 
 * [`renderProp`](docs/render-prop.md)
+* [`drill`](docs/drill.md)
 * [`until`](docs/until.md)

--- a/docs/drill.md
+++ b/docs/drill.md
@@ -1,0 +1,112 @@
+# `.drill(expander) => ShallowWrapper`
+
+Shallow render the result of calling a property, defined by the expander function.
+
+NOTE: can only be called on wrapper of a single non-DOM component element node.
+
+#### Arguments
+
+1.  `expander` (`Function => ShallowWrapper`): This function gets called with the `props` of the current wrapper. The expander function should call one of the properties and return the resulting element.
+
+#### Returns
+
+`ShallowWrapper`: A new wrapper that wraps the node returned from the expander function, after it's been shallowly rendered.
+
+#### Examples
+
+##### Test Setup
+
+```jsx
+class Mouse extends React.Component {
+  static propTypes = { render: PropTypes.func.isRequired };
+  state = { x: 0, y: 0 };
+  handleMouseMove = event => {
+    this.setState({
+      x: event.clientX,
+      y: event.clientY,
+    });
+  };
+  render() {
+    return (
+      <div style={{ height: '100%' }} onMouseMove={this.handleMouseMove}>
+        {this.props.render(this.state)}
+      </div>
+    );
+  }
+}
+```
+
+```jsx
+class App extends React.Component {
+  render() {
+    return (
+      <div style={{ height: '100%' }}>
+        <Mouse
+          render={(x = 0, y = 0) => (
+            <h1>
+              The mouse position is {x}, {y}
+            </h1>
+          )}
+        />
+      </div>
+    );
+  }
+}
+```
+
+##### Test with multiple arguments
+
+```jsx
+const wrapper = shallow(<App />)
+  .find(Mouse)
+  .drill(props => props.render(10, 20));
+
+expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).toBe(true);
+```
+
+##### Test returning custom wrapper
+
+```jsx
+const wrapper = shallow(<App />)
+  .find(Mouse)
+  .drill(props => <div>{props.render(10, 20)}</div>);
+
+expect(
+  wrapper.equals(
+    <div>
+      <h1>The mouse position is 10, 20</h1>
+    </div>
+  )
+).toBe(true);
+```
+
+##### Test when explicit shallow rendering is necessary
+
+```jsx
+const wrapper = shallow(
+  <div>
+    <Mouse
+      render={(x = 0, y = 0) => (
+        <form>
+          <div>
+            The mouse position is {x}, {y}
+          </div>
+        </form>
+      )}
+    />
+  </div>
+)
+  .find(Mouse)
+  .drill(props => props.render(10, 20))
+  // explicit shallow() call is required here, otherwise the wrapper
+  // would only contain <form />
+  .shallow();
+
+expect(
+  wrapper.shallow().equals(
+    <form>
+      <div>The mouse position is 10, 20</div>
+    </form>
+  )
+).toBe(true);
+```

--- a/docs/render-prop.md
+++ b/docs/render-prop.md
@@ -1,21 +1,24 @@
-# `.renderProp(expander) => ShallowWrapper`
+# `.renderProp(propName, ...args) => ShallowWrapper`
 
-Shallow render the result of calling a property, defined by the expander function.
+Calls the current wrapper's property with name `propName` and the `args` provided.
+Returns the result in a new shallow wrapper.
 
 NOTE: can only be called on wrapper of a single non-DOM component element node.
 
 #### Arguments
 
-1.  `expander` (`Function => ShallowWrapper` | `String`):
+1.  `propName` (`String`):
+1.  `...args` (`Any`):
 
-* when a `String` is passed: The `prop` with that name is called and its return value is used. It is not possible to pass any arguments when using a string.
-* when a `Function` is passed: This function gets called with the `props` of the current wrapper. The expander function should call one of the properties and return the result.
+This essentially calls `wrapper.prop(propName)(...args)`.
 
 #### Returns
 
 `ShallowWrapper`: A new wrapper that wraps the node returned from the expander function, after it's been shallowly rendered.
 
 #### Examples
+
+##### Test Setup
 
 ```jsx
 class Mouse extends React.Component {
@@ -51,22 +54,26 @@ class App extends React.Component {
         />
       </div>
     );
-  },
-});
+  }
+}
 ```
 
-```jsx
-const wrapper = shallow(<App />)
-  .find(Mouse)
-  .renderProp(props => props.render(10, 20));
-
-expect(wrapper.text()).toEqual('The mouse position is (10, 20)');
-```
+##### Testing with no arguments
 
 ```jsx
 const wrapper = shallow(<App />)
   .find(Mouse)
   .renderProp('render');
 
-expect(wrapper.text()).toEqual('The mouse position is (0, 0)');
+expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).toBe(true);
+```
+
+##### Testing with multiple arguments
+
+```jsx
+const wrapper = shallow(<App />)
+  .find(Mouse)
+  .renderProp('render', 10, 20);
+
+expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).toBe(true);
 ```

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "jest-runner-eslint": "0.5.0",
   "lint-staged": "7.1.0",
   "prettier": "1.12.1",
+  "prop-types": "15.6.1",
   "react": "^16.3.2",
   "react-dom": "^16.3.2"
  },

--- a/src/configure/configure.js
+++ b/src/configure/configure.js
@@ -1,7 +1,9 @@
 const until = require('../until');
 const renderProp = require('../render-prop');
+const drill = require('../drill');
 
 module.exports = function configure(ShallowWrapper) {
   ShallowWrapper.prototype.renderProp = renderProp;
   ShallowWrapper.prototype.until = until;
+  ShallowWrapper.prototype.drill = drill;
 };

--- a/src/configure/configure.spec.js
+++ b/src/configure/configure.spec.js
@@ -24,4 +24,13 @@ describe('configure', () => {
       );
     });
   });
+
+  describe('`drill`', () => {
+    it('should be assigned on the passed `ShallowWrapper` prototype', () => {
+      expect(ShallowWrapper.prototype).toHaveProperty(
+        'drill',
+        expect.any(Function)
+      );
+    });
+  });
 });

--- a/src/drill/drill.js
+++ b/src/drill/drill.js
@@ -7,9 +7,9 @@ const shallowRenderProp = (wrapper, expander) =>
     ? wrapper.prop(expander)()
     : expander(wrapper.props());
 
-module.exports = function renderProp(expander) {
+module.exports = function drill(expander) {
   // throws an error if the current instance has a length other than one.
-  return this.single('renderProp', () =>
+  return this.single('drill', () =>
     // create a new wrapper with the same root as the current wrapper,
     // with any nodes passed in as the first parameter automatically wrapped
     this.wrap(shallowRenderProp(this, expander))

--- a/src/drill/drill.js
+++ b/src/drill/drill.js
@@ -1,0 +1,17 @@
+const React = require('react');
+const omit = require('lodash.omit');
+const { shallow } = require('enzyme');
+
+const shallowRenderProp = (wrapper, expander) =>
+  typeof expander === 'string'
+    ? wrapper.prop(expander)()
+    : expander(wrapper.props());
+
+module.exports = function renderProp(expander) {
+  // throws an error if the current instance has a length other than one.
+  return this.single('renderProp', () =>
+    // create a new wrapper with the same root as the current wrapper,
+    // with any nodes passed in as the first parameter automatically wrapped
+    this.wrap(shallowRenderProp(this, expander))
+  );
+};

--- a/src/drill/drill.spec.js
+++ b/src/drill/drill.spec.js
@@ -53,7 +53,7 @@ describe('drill', () => {
 
       it('should return a shallow wrapper containing the render prop output', () => {
         expect(wrapper).toBeInstanceOf(ShallowWrapper);
-        expect(wrapper.contains(<div>Cursor is at 2</div>)).toBe(true);
+        expect(wrapper.equals(<div>Cursor is at 2</div>)).toBe(true);
       });
     });
 
@@ -78,7 +78,7 @@ describe('drill', () => {
 
       it('should return a shallow wrapper containing the render prop output', () => {
         expect(wrapper).toBeInstanceOf(ShallowWrapper);
-        expect(wrapper.contains(<div>Cursor is at 2 3</div>)).toBe(true);
+        expect(wrapper.equals(<div>Cursor is at 2 3</div>)).toBe(true);
       });
     });
 
@@ -97,7 +97,7 @@ describe('drill', () => {
 
       it('should return a shallow wrapper containing the render prop output', () => {
         expect(wrapper).toBeInstanceOf(ShallowWrapper);
-        expect(wrapper.contains(<div>Cursor is there</div>)).toBe(true);
+        expect(wrapper.equals(<div>Cursor is there</div>)).toBe(true);
       });
     });
   });
@@ -130,7 +130,7 @@ describe('drill', () => {
     });
 
     it('should expand them sequentially', () => {
-      expect(wrapper.contains(<div>Cursor is at 2 4</div>)).toBe(true);
+      expect(wrapper.equals(<div>Cursor is at 2 4</div>)).toBe(true);
     });
   });
 
@@ -152,7 +152,7 @@ describe('drill', () => {
 
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
-      expect(wrapper.contains(<div>What we want to render</div>)).toBe(true);
+      expect(wrapper.equals(<div>What we want to render</div>)).toBe(true);
     });
   });
 
@@ -174,7 +174,7 @@ describe('drill', () => {
     });
 
     it('should render from context', () => {
-      expect(wrapper.contains(<div>Position is 10</div>)).toBe(true);
+      expect(wrapper.equals(<div>Position is 10</div>)).toBe(true);
     });
   });
 
@@ -198,7 +198,7 @@ describe('drill', () => {
 
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
-      expect(wrapper.contains('Cursor is at 2')).toBe(true);
+      expect(wrapper.equals('Cursor is at 2')).toBe(true);
     });
   });
 
@@ -213,7 +213,7 @@ describe('drill', () => {
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
       expect(wrapper.find(Foo)).toHaveLength(1);
-      expect(wrapper.contains(<Foo x={2} />)).toBe(true);
+      expect(wrapper.equals(<Foo x={2} />)).toBe(true);
     });
   });
 
@@ -242,7 +242,7 @@ describe('drill', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
       expect(wrapper.find(Foo)).toHaveLength(1);
       expect(
-        wrapper.contains(
+        wrapper.equals(
           <form>
             <Foo />
           </form>
@@ -268,9 +268,9 @@ describe('drill', () => {
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
       expect(wrapper.find(Foo)).toHaveLength(1);
-      expect(wrapper.contains(<Foo someX={2} />)).toBe(true);
-      expect(wrapper.contains(<div>Wow</div>)).toBe(false);
-      expect(wrapper.shallow().contains(<div>Wow</div>)).toBe(true);
+      expect(wrapper.equals(<Foo someX={2} />)).toBe(true);
+      expect(wrapper.equals(<div>Wow</div>)).toBe(false);
+      expect(wrapper.shallow().equals(<div>Wow</div>)).toBe(true);
     });
   });
 });

--- a/src/drill/index.js
+++ b/src/drill/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./drill');

--- a/src/examples.spec.js
+++ b/src/examples.spec.js
@@ -1,0 +1,150 @@
+const React = require('react');
+const Enzyme = require('enzyme');
+const PropTypes = require('prop-types');
+const { shallow } = Enzyme;
+const Adapter = require('enzyme-adapter-react-16');
+const ShallowWrapper = require('enzyme/ShallowWrapper');
+
+// This is a test suite to ensure the examples are working
+beforeAll(() => {
+  Enzyme.configure({ adapter: new Adapter() });
+  ShallowWrapper.prototype.drill = require('../src/drill');
+  ShallowWrapper.prototype.renderProp = require('../src/render-prop');
+});
+
+describe('drill', () => {
+  class Mouse extends React.Component {
+    static propTypes = { render: PropTypes.func.isRequired };
+    state = { x: 0, y: 0 };
+    handleMouseMove = event => {
+      this.setState({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
+    render() {
+      return (
+        <div style={{ height: '100%' }} onMouseMove={this.handleMouseMove}>
+          {this.props.render(this.state)}
+        </div>
+      );
+    }
+  }
+
+  class App extends React.Component {
+    render() {
+      return (
+        <div style={{ height: '100%' }}>
+          <Mouse
+            render={(x = 0, y = 0) => (
+              <h1>
+                The mouse position is {x}, {y}
+              </h1>
+            )}
+          />
+        </div>
+      );
+    }
+  }
+
+  it('should work with multiple arguments', () => {
+    const wrapper = shallow(<App />)
+      .find(Mouse)
+      .drill(props => props.render(10, 20));
+
+    expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).toBe(true);
+  });
+
+  it('should work when returning a custom wrapper', () => {
+    const wrapper = shallow(<App />)
+      .find(Mouse)
+      .drill(props => <div>{props.render(10, 20)}</div>);
+
+    expect(
+      wrapper.equals(
+        <div>
+          <h1>The mouse position is 10, 20</h1>
+        </div>
+      )
+    ).toBe(true);
+  });
+
+  it('should work when rendering component with render-prop at top-level', () => {
+    const wrapper = shallow(
+      <div>
+        <Mouse
+          render={(x = 0, y = 0) => (
+            <form>
+              <div>
+                The mouse position is {x}, {y}
+              </div>
+            </form>
+          )}
+        />
+      </div>
+    )
+      .find(Mouse)
+      .drill(props => props.render(10, 20))
+      .shallow();
+
+    expect(
+      wrapper.shallow().equals(
+        <form>
+          <div>The mouse position is 10, 20</div>
+        </form>
+      )
+    ).toBe(true);
+  });
+});
+
+describe('renderProp', () => {
+  class Mouse extends React.Component {
+    static propTypes = { render: PropTypes.func.isRequired };
+    state = { x: 0, y: 0 };
+    handleMouseMove = event => {
+      this.setState({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
+    render() {
+      return (
+        <div style={{ height: '100%' }} onMouseMove={this.handleMouseMove}>
+          {this.props.render(this.state)}
+        </div>
+      );
+    }
+  }
+
+  class App extends React.Component {
+    render() {
+      return (
+        <div style={{ height: '100%' }}>
+          <Mouse
+            render={(x = 0, y = 0) => (
+              <h1>
+                The mouse position is {x}, {y}
+              </h1>
+            )}
+          />
+        </div>
+      );
+    }
+  }
+
+  it('should work with no arguments', () => {
+    const wrapper = shallow(<App />)
+      .find(Mouse)
+      .renderProp('render');
+
+    expect(wrapper.equals(<h1>The mouse position is 0, 0</h1>)).toBe(true);
+  });
+
+  it('should work with multiple arguments', () => {
+    const wrapper = shallow(<App />)
+      .find(Mouse)
+      .renderProp('render', 10, 20);
+
+    expect(wrapper.equals(<h1>The mouse position is 10, 20</h1>)).toBe(true);
+  });
+});

--- a/src/render-prop/render-prop.js
+++ b/src/render-prop/render-prop.js
@@ -2,16 +2,27 @@ const React = require('react');
 const omit = require('lodash.omit');
 const { shallow } = require('enzyme');
 
-const shallowRenderProp = (wrapper, expander) =>
-  typeof expander === 'string'
-    ? wrapper.prop(expander)()
-    : expander(wrapper.props());
+// A wrapper component so that we can shallow-render immediately
+const Wrapper = props => props.children;
+Wrapper.displayName = 'Wrapper';
 
-module.exports = function renderProp(expander) {
-  // throws an error if the current instance has a length other than one.
-  return this.single('renderProp', () =>
-    // create a new wrapper with the same root as the current wrapper,
-    // with any nodes passed in as the first parameter automatically wrapped
-    this.wrap(shallowRenderProp(this, expander))
-  );
+module.exports = function renderProp(propName, ...args) {
+  return this.single('renderProp', () => {
+    if (typeof propName !== 'string')
+      throw new Error(
+        '@commercetools/enzyme-extensions/renderProp: first argument must be the name of a prop'
+      );
+    const prop = this.prop(propName);
+    if (!prop)
+      throw new Error(
+        `@commercetools/enzyme-extensions/renderProp: no prop called "${propName}" found`
+      );
+    if (typeof prop !== 'function')
+      throw new Error(
+        `@commercetools/enzyme-extensions/renderProp: expected prop "${propName}" to contain a function, but it holds "${typeof prop}"`
+      );
+    const element = prop(...args);
+    const wrapped = React.createElement(Wrapper, null, element);
+    return this.wrap(wrapped).shallow();
+  });
 };

--- a/src/render-prop/render-prop.spec.js
+++ b/src/render-prop/render-prop.spec.js
@@ -53,7 +53,7 @@ describe('renderProp', () => {
 
       it('should return a shallow wrapper containing the render prop output', () => {
         expect(wrapper).toBeInstanceOf(ShallowWrapper);
-        expect(wrapper.contains(<div>Cursor is at 2</div>)).toBe(true);
+        expect(wrapper.equals(<div>Cursor is at 2</div>)).toBe(true);
       });
     });
 
@@ -78,7 +78,7 @@ describe('renderProp', () => {
 
       it('should return a shallow wrapper containing the render prop output', () => {
         expect(wrapper).toBeInstanceOf(ShallowWrapper);
-        expect(wrapper.contains(<div>Cursor is at 2 3</div>)).toBe(true);
+        expect(wrapper.equals(<div>Cursor is at 2 3</div>)).toBe(true);
       });
     });
 
@@ -133,7 +133,7 @@ describe('renderProp', () => {
     });
 
     it('should expand them sequentially', () => {
-      expect(wrapper.contains(<div>Cursor is at 2 4</div>)).toBe(true);
+      expect(wrapper.equals(<div>Cursor is at 2 4</div>)).toBe(true);
     });
   });
 
@@ -155,7 +155,7 @@ describe('renderProp', () => {
 
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
-      expect(wrapper.contains(<div>What we want to render</div>)).toBe(true);
+      expect(wrapper.equals(<div>What we want to render</div>)).toBe(true);
     });
   });
 
@@ -177,7 +177,7 @@ describe('renderProp', () => {
     });
 
     it('should render from context', () => {
-      expect(wrapper.contains(<div>Position is 10</div>)).toBe(true);
+      expect(wrapper.equals(<div>Position is 10</div>)).toBe(true);
     });
   });
 
@@ -201,7 +201,7 @@ describe('renderProp', () => {
 
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
-      expect(wrapper.contains('Cursor is at 2')).toBe(true);
+      expect(wrapper.equals('Cursor is at 2')).toBe(true);
     });
   });
 
@@ -216,7 +216,7 @@ describe('renderProp', () => {
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
       expect(wrapper.find(Foo)).toHaveLength(1);
-      expect(wrapper.contains(<Foo x={2} />)).toBe(true);
+      expect(wrapper.equals(<Foo x={2} />)).toBe(true);
     });
   });
 
@@ -244,7 +244,7 @@ describe('renderProp', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
       expect(wrapper.find(Foo)).toHaveLength(1);
       expect(
-        wrapper.contains(
+        wrapper.equals(
           <form>
             <Foo />
           </form>
@@ -270,13 +270,13 @@ describe('renderProp', () => {
     it('should return a shallow wrapper containing the render prop output', () => {
       expect(wrapper).toBeInstanceOf(ShallowWrapper);
       expect(wrapper.find(Foo)).toHaveLength(1);
-      expect(wrapper.contains(<Foo someX={2} />)).toBe(true);
-      expect(wrapper.contains(<div>Wow</div>)).toBe(false);
+      expect(wrapper.equals(<Foo someX={2} />)).toBe(true);
+      expect(wrapper.equals(<div>Wow</div>)).toBe(false);
       expect(
         wrapper
           .find(Foo)
           .shallow()
-          .contains(<div>Wow</div>)
+          .equals(<div>Wow</div>)
       ).toBe(true);
     });
   });

--- a/src/sanity.spec.js
+++ b/src/sanity.spec.js
@@ -26,7 +26,7 @@ describe('when not expanding', () => {
     );
     const wrapper = shallow(<App />);
     expect(
-      wrapper.contains(
+      wrapper.equals(
         <div id="app">
           <Mouse render={renderFn} />
         </div>
@@ -46,7 +46,7 @@ describe('when expanding a regular component with children', () => {
     const wrapper = shallow(<App />);
     expect(wrapper.find(Foo)).toHaveLength(1);
     expect(
-      wrapper.contains(
+      wrapper.equals(
         <form>
           <Foo />
         </form>
@@ -94,7 +94,7 @@ describe('context', () => {
       const context = { position: 10 };
       const wrapper = shallow(<App />, { context });
       expect(
-        wrapper.contains(
+        wrapper.equals(
           <div id="app">
             <div>Position is 10</div>
           </div>
@@ -122,11 +122,14 @@ describe('context', () => {
           </App>
         </div>
       );
+
       expect(
-        wrapper.contains(
-          <App>
-            <div id="some-app-child" />
-          </App>
+        wrapper.equals(
+          <div>
+            <App>
+              <div id="some-app-child" />
+            </App>
+          </div>
         )
       ).toBe(true);
     });

--- a/src/sanity.spec.js
+++ b/src/sanity.spec.js
@@ -1,0 +1,134 @@
+const React = require('react');
+const Enzyme = require('enzyme');
+const PropTypes = require('prop-types');
+const { shallow } = Enzyme;
+const Adapter = require('enzyme-adapter-react-16');
+const ShallowWrapper = require('enzyme/ShallowWrapper');
+
+// This is a test suite to ensure some enzyme behavior these extensions assume
+const Mouse = props => (
+  <div id="mouse">{props.render({ x: Math.random() })}</div>
+);
+let App;
+let wrapper;
+
+beforeAll(() => {
+  Enzyme.configure({ adapter: new Adapter() });
+});
+
+describe('when not expanding', () => {
+  it('should render shallowly', () => {
+    const renderFn = ({ x }) => `Cursor is at ${x}`;
+    const App = () => (
+      <div id="app">
+        <Mouse render={renderFn} />
+      </div>
+    );
+    const wrapper = shallow(<App />);
+    expect(
+      wrapper.contains(
+        <div id="app">
+          <Mouse render={renderFn} />
+        </div>
+      )
+    ).toBe(true);
+  });
+});
+
+describe('when expanding a regular component with children', () => {
+  it('should return a shallow wrapper containing the render prop output', () => {
+    const Foo = () => <div>Wow</div>;
+    const App = () => (
+      <form>
+        <Foo />
+      </form>
+    );
+    const wrapper = shallow(<App />);
+    expect(wrapper.find(Foo)).toHaveLength(1);
+    expect(
+      wrapper.contains(
+        <form>
+          <Foo />
+        </form>
+      )
+    ).toBe(true);
+  });
+});
+
+describe('shallow-rendering', () => {
+  it('renders', () => {
+    const Bar = () => (
+      <div>
+        <div className="in-bar" />
+      </div>
+    );
+    const Foo = () => (
+      <div>
+        <Bar />
+      </div>
+    );
+    const wrapper = shallow(<Foo />);
+    expect(wrapper.find('.in-bar')).toHaveLength(0);
+    expect(wrapper.find(Bar)).toHaveLength(1);
+    expect(
+      wrapper
+        .find(Bar)
+        .shallow()
+        .find('.in-bar')
+    ).toHaveLength(1);
+  });
+});
+
+describe('context', () => {
+  describe('when top-level component requires context', () => {
+    it('should render from context', () => {
+      const App = (props, context) => (
+        <div id="app">
+          <div>Position is {context.position}</div>
+        </div>
+      );
+      // We need to define the contextTypes so that the App has access to
+      // the foo context slice
+      App.contextTypes = { position: PropTypes.number.isRequired };
+
+      const context = { position: 10 };
+      const wrapper = shallow(<App />, { context });
+      expect(
+        wrapper.contains(
+          <div id="app">
+            <div>Position is 10</div>
+          </div>
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('when nested component requires context', () => {
+    it('should render from context', () => {
+      const App = (props, context) => (
+        <div id="app">
+          <div>Position is {context.position}</div>
+        </div>
+      );
+      // We need to define the contextTypes so that the App has access to
+      // the foo context slice
+      App.contextTypes = { position: PropTypes.number.isRequired };
+
+      // we are nesting so we don't need to pass the context of App
+      const wrapper = shallow(
+        <div>
+          <App>
+            <div id="some-app-child" />
+          </App>
+        </div>
+      );
+      expect(
+        wrapper.contains(
+          <App>
+            <div id="some-app-child" />
+          </App>
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/src/until/until.spec.js
+++ b/src/until/until.spec.js
@@ -23,8 +23,8 @@ describe('until', () => {
     });
 
     it('should render (dives to) the wrapper', () => {
-      expect(wrapper.contains(<Foo />)).toBe(true);
-      expect(wrapper.dive().contains(<Div />)).toBe(true);
+      expect(wrapper.equals(<Foo />)).toBe(true);
+      expect(wrapper.dive().equals(<Div />)).toBe(true);
     });
   });
 
@@ -35,8 +35,8 @@ describe('until', () => {
     });
 
     it('should render (dives to) the wrapper', () => {
-      expect(wrapper.contains(<Foo />)).toBe(true);
-      expect(wrapper.dive().contains(<Div />)).toBe(true);
+      expect(wrapper.equals(<Foo />)).toBe(true);
+      expect(wrapper.dive().equals(<Div />)).toBe(true);
     });
   });
 
@@ -58,8 +58,8 @@ describe('until', () => {
     });
 
     it('should render the wrapper', () => {
-      expect(wrapper.contains(<Foo />)).toBe(true);
-      expect(wrapper.dive().contains(<Div />)).toBe(true);
+      expect(wrapper.equals(<Foo />)).toBe(true);
+      expect(wrapper.dive().equals(<Div />)).toBe(true);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4792,7 +4792,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@15.6.1, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:


### PR DESCRIPTION
- makes `renderProp` more convenient
- keeps `drill` as a primitive