### PR TITLE
Remove check-node-version and support node v6 and upwards

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
  "description": "Enzyme extensions tailored at improving dealing with shallowly rendered wrappers",
  "main": "src/index.js",
  "scripts": {
-  "postinstall": "check-node-version --package --print",
   "precommit": "lint-staged",
   "format": "npm run format:md && npm run format:js",
   "commitmsg": "commitlint -e $GIT_PARAMS",
@@ -52,7 +51,6 @@
   "babel-preset-env": "1.7.0",
   "babel-preset-react": "6.24.1",
   "babel-preset-stage-0": "^6.24.1",
-  "check-node-version": "3.2.0",
   "codecov": "3.0.2",
   "cross-env": "5.1.6",
   "enzyme": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "url": "git+https://github.com/commercetools/enzyme-extensions.git"
  },
  "engines": {
-  "node": ">=8",
+  "node": ">=6",
   "npm": ">=3"
  },
  "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,7 +1548,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1559,18 +1559,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
-
-check-node-version@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/check-node-version/-/check-node-version-3.2.0.tgz#783a4292dbf76d6b8294b23abece33682b4a7cce"
-  dependencies:
-    chalk "^2.3.0"
-    map-values "^1.0.1"
-    minimist "^1.2.0"
-    object-filter "^1.0.2"
-    object.assign "^4.0.4"
-    run-parallel "^1.1.4"
-    semver "^5.0.3"
 
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
@@ -4204,10 +4192,6 @@ map-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
 
-map-values@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/map-values/-/map-values-1.0.1.tgz#768b8e79c009bf2b64fee806e22a7b1c4190c990"
-
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -4588,10 +4572,6 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
-
-object-filter@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/object-filter/-/object-filter-1.0.2.tgz#af0b797ffebeaf8a52c6637cedbe8816cfec1bc8"
 
 object-inspect@^1.5.0:
   version "1.6.0"
@@ -5384,10 +5364,6 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-run-parallel@^1.1.4:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
-
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
@@ -5445,7 +5421,7 @@ semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
 
-"semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.3, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION

#### Summary
- removes `check-node-version`
- supports node v6 and upwards

#### Details

Previously this would fail

```
mkdir foo
cd foo
npm init --yes
npm install @commercetools/enzyme-extensions
```

with

```
sh: check-node-version: command not found
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! @commercetools/enzyme-extensions@3.0.0 postinstall: `check-node-version --package --print`
npm ERR! spawn ENOENT
npm ERR!
npm ERR! Failed at the @commercetools/enzyme-extensions@3.0.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

Now it will work because I removed `check-node-version`. It wasn't doing much in the first place, so 